### PR TITLE
Implemented client certificate validation callback

### DIFF
--- a/Examples/SampleApp/Examples/CustomEndpointListenerExample.cs
+++ b/Examples/SampleApp/Examples/CustomEndpointListenerExample.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Pipelines;
+using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -80,7 +81,7 @@ namespace SampleApp.Examples
                 _securableDuplexPipe = securableDuplexPipe;
             }
 
-            public Task UpgradeAsync(X509Certificate certificate, SslProtocols protocols, CancellationToken cancellationToken = default)
+            public Task UpgradeAsync(X509Certificate certificate, SslProtocols protocols, CancellationToken cancellationToken = default, RemoteCertificateValidationCallback remoteCertificateValidationCallback = null)
             {
                 return _securableDuplexPipe.UpgradeAsync(certificate, protocols, cancellationToken);
             }

--- a/Examples/SampleApp/Examples/UnsecureServerExample.cs
+++ b/Examples/SampleApp/Examples/UnsecureServerExample.cs
@@ -10,7 +10,7 @@ using SmtpServer.Tracing;
 
 namespace SampleApp.Examples
 {
-    public static class UnsecureServerExample
+    public static class SecureServerExample
     {
         public static void Run()
         {
@@ -24,7 +24,7 @@ namespace SampleApp.Examples
                 .Endpoint(builder =>
                     builder
                         .Port(9025)
-                        .IsSecure(true)
+                        .IsSecure(false)
                         .AuthenticationRequired(true)
                         .AllowUnsecureAuthentication(false)
                         .Certificate(CreateCertificate()))
@@ -32,6 +32,8 @@ namespace SampleApp.Examples
 
             var serviceProvider = new ServiceProvider();
             serviceProvider.Add(new SampleUserAuthenticator());
+            // Client certificate validation will only be performed if the endpoint is not secure by default.
+            serviceProvider.Add(new SampleClientCertificateValidator());
 
             var server = new SmtpServer.SmtpServer(options, serviceProvider);
             server.SessionCreated += OnSessionCreated;

--- a/Examples/SampleApp/SampleClientCertificateValidator.cs
+++ b/Examples/SampleApp/SampleClientCertificateValidator.cs
@@ -1,0 +1,16 @@
+﻿using System.Net.Security;
+using SmtpServer.Authentication;
+
+namespace SampleApp
+{
+    public sealed class SampleClientCertificateValidator : ClientCertificateValidator
+    {
+        public override RemoteCertificateValidationCallback RemoteClientCertificateValidationCallback { get; set; } =
+            (sender, certificate, chain, sslPolicyErrors) =>
+            {
+                // Provide your custom client certificate validation logic here.
+                // Return true if valid; otherwise, false.
+                return true;
+            };
+    }
+}

--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit;
+using MailKit.Security;
 using SmtpServer.Mail;
 using SmtpServer.Tests.Mocks;
 using Xunit;
@@ -21,6 +22,9 @@ namespace SmtpServer.Tests
 {
     public class SmtpServerTests
     {
+        private const string Base64Certificate = "MIINogIBAzCCDV4GCSqGSIb3DQEHAaCCDU8Egg1LMIINRzCCBgAGCSqGSIb3DQEHAaCCBfEEggXtMIIF6TCCBeUGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAgdGgf80T28bQICB9AEggTY7VJO9rz/c84rrfB51kzVpRQNuX0GmQQmXtOqS626bdrsJX395Vkk8qBi+7dekPmVSFLIvIpTHXKpt7gUj4yc3Ir9AfAFif7cHU+tTexHQ1BQoUVmPsJ8+l9xAkmPOZwm6bBMT8zU3v0HtD+avQDAXIKHEjhCPNxGlL78XdfVuWOS1vm4A+yaYd6KwzgRAfnn/2v6ttLJ89AidQ5ZmNFrzlqH4GccbMkPwBb8/hkLxAq49QVjYofetec/rcCyl/UfXOraNRxKedswquu6CfvSGuQ8U7tfnxj9CXLjPu+rHJgm3CNDZzLhmyVESSg1JT1QtsiZMdt8+u/H3RevJvRJAPn1DqW8l8OWCOstyDBusuiJA+B5C7VBq9FKKzLXpmLBN+2sH1wOn4OeDW5N1CZrlNbRkr8jjZinlqE+8A/5CFbZzj8SRZmhhSir/GkU5dICKsn3c1pO+dqr42KsYP3gzs1na5u4vKuJ81yDZY5FoiWD5GAeH7LqBsF2D2FUIeoxbzsJ3eZw9h7oNnttborFuDHXiI/KCz6m0F80LlB/BRbMDNWipfuulcYfAzGud7b/XLLFRxmbnaUqkOb+qDJYLOkTUrbFhkTSMTBeHNPnCvwSgZlH5pEnbGvn1iZZmr2vqzFqgfcFnfMEM3z96juyNlNYg8gomublL8hwwaucMZvoMzEQLE1GnfRE3K/GIfwgm5izRTxKZPIvhUnFiVe40nub3Xj2rAjKpBCRqTVKyLawNo5vAp3blB6IXBesj8Ryy0y/e7wIfFKfHk+yRWbyA34bhDEVs696eXYvVoM6SdyKaN/eTLwKNaYum73dPKwliUme/h6SxfnIIjimpm9vbGAjaY04xktHruQUajJVq1ryyE05EB7k5weINtKI+XgFKJr7nmNNWX8/pCpMfKDOqCs/HjmZW6+9qFDit20Dl1cLEuTZO8twMP9qsZAXKMICQQcSnmMFdnMzuMeQ9PlbRz37denCG2uVcspN9LjhkTzADAzk6XDzxHYdGeJ4FhfGF92jqCtLvX7J08w0OEQ3o1+Qci5qcA8vb+gbX+UIFQ+eTjXCvNRkhtrXtbOqlP6YP7LE+ApHgymvPDTI1QDn+5pfm264AN+rWDNEoOH1CgDZUkMdulIxtQqut/HydWa5LfP87xGehHECZ1X0ldpVOv3UHTQcEC0//9gGWfH2R6cRgNbFRnicEQ1yawD5t3qNzyjv9sySamD2KQD8DxB1g5VvNS4kDqasSYsH802W7vMOUNX4dpGjhSQh7x0aR+i60HJRCUP/ZyjO1uH/rydahwYJPSZqjVhMYt4RVaPLgGd9hqoh560nUEBEGgoeulzpobm6KVHYXrPNOxNUhZ0tPUyBSrGJDy+pCOd088EopZaa4MlekV6tqFYl6CPkEXYECvrfMtp1nRk3ZOHONzHJ5gZ6wFar4dWXt74YH6eeANweYvr8Y9+plZEm4ZUvdYS142Hf19RrlbcgIRzG++NUq4YKRn21D1RoRw0SoJnK6GWg7GOhDkUNG+OrEdFT5OsDsJhEClt87iynlYx5khr4i5b80fKEn+VtTxJYNPr9ekE6Kw3C1jpXG2rnQEmCdPfrurZGWrD4V4s4Ov8YytfYtjaVpQNNpaasg/PPs55R0xWIjLSKdN69YzGB0zATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkqhkiG9w0BCRQxUB5OAHQAZQAtADkAYwAyAGUAZAAwAGYANQAtADIANABiADQALQA0ADcAZgBiAC0AYQAwAGUAYwAtADkAZgA4ADgAMgBlAGMAYgAzAGYAZAA1MF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAG8AZgB0AHcAYQByAGUAIABLAGUAeQAgAFMAdABvAHIAYQBnAGUAIABQAHIAbwB2AGkAZABlAHIwggc/BgkqhkiG9w0BBwagggcwMIIHLAIBADCCByUGCSqGSIb3DQEHATAcBgoqhkiG9w0BDAEDMA4ECDPyaqU0D3m4AgIH0ICCBvjhmxCuqQ+V89QSXxWcYboTOAbPXqzyTcJsYTjWETD1upA1R3wO7i/F6QV85FykdEVvfUE5lRA+G/xAEx+pF0Ti4qrkuDzLf+rBwAApfZy/oU+FaVkpnEjwYt1xsT6rY6hK5LhBQhQFY9xh6tNxmd4ODzAPyR5SbfOOxjBn+JdzD8kG3HoziZ2S1ha+5dgpyWSm1ScSbJdLabEpfbTWvaF4OCRqqezMIuoSyt0/BaOu+/Ijf5oOnAc7VQz/bdo9tJweru7gpcGBKO0TI+yp22p5QP+XlqzmFXcBg3YRIJggpQvtm06BLI4P/hZPoWU/cDsMtNo7D8gESXug+PGCBZ0SBMK2nyFPSBc2Sx9SgPgsuu/1z4DUm51vjOLSH676y4AsK559ZBFwZL5iFOc7w2OaFcl6Kib8mykIuWYQNP/fdDmeHYBGQDhuJLuuyv4Q/+s7WhzT2SYZltoVQgvSR+9gTT2m8+D+SSzyUu5e0okPZNodHMM2ZTT3f8P1NE4B0rYEMXrweF6bL/0lx8dn8j6XvC0GaLDi6l5F3m9ih8C+tYiREXrvkZI7gKrG0frTtyJjCJgxcSpJ9VBDcQCqVzZmdPFRlVko/n37kDM+QTQi/nzuiDvtwkBpc6Mq70bM+yghOhGAeYE4X18ZCmKupGngp8BDHdlj6FWp/l0FezukVhyRbYoiJBxtM+DBjNJCum066EL7XuRO6UOvdGD9sYc6Dk+SDjwj3ldvCsnyH2yggTN/JjCLprKPa3HPTHEAIFTlWc4YRXD0IZudMFGxr+Ds6l7Ue+gYo1VV4s0L5hnKoO7QKEmACmyyPJZK90FbfTB7EuVc48IOwrmlqy1gz98Xfg9wQQ7yQ59L7EHzvz+f2nKGVBd2OGaaBImNH8590DROOMziY1Cq8nxc8QtMzCE0CTFeFBAzx7fQQy8WybLZMtgsRv4xF1qiDESwBSvrPlXZkBYybuuhRpWcgWjAZirJW3JNfVrg6Jbya7w2OkyIzW9FteB+ib/KfB4jbSFoiKMfkwXeqsyLWjvtY01kfqS/YZH+t4D/0KR+702LZdzfJ/6rzdGXuR5nwSol8fvunD4jP7E5ln0VIppHLxyn/Ugb9717ZIEEsa55D+xTutNNQJpPCsPkkQq1TXUxR2KblfkVWptbmkCwx1jLWHpZezsclDFktT1wl72yzOBPo0Rz8LIJJRcYhyZ5yUnCocCd2PvzYOEE9+j6atucjA4WsF95cLuQFqNg+Sfh/fPaZeLUteAFzcYvhryxwZvAotBNVZ6tLHsDCI/CTHwcgV60CAfM32EfPJpSvd/DVTYuV1i2qbLJlZNfc0lcRxF65LheVqDJBlTYjWDVoLJYpzqMYFm2y06Psby74wsenlJ0ZmTQwEjLTA7jYMNx0uo8FQqf+ekmZhXKMwwE+ljubMq9IW34yt38jRVnWg94lE4RFyEgJAD3j9rPRnlF6YQjyd2piGk1ngEhjGBsECDv6oB+YfxHwUIbn+eH+5s/LFudjBww3m/QorAwy6Vwg4xfAto9vMl8Ghic10vP4XjYNAJ62C76VMD530jlsBMfjDeZvOWr+hJafPCx3MWhMd3ZLpttbkHAQnf60UjajvOxsP1c49n7H/1nu1fFfnIVzorMiJGlb9NwqDakXJG0+Nqr4XZcJ6EgJoqixCrd/ofzDV/Q7eivXOk7Ig67CHcy3yyCPLZ2hkWN/8y9z+4/CK1nJw23+PnictCIGbt59bBlFV75qmx+f9fN3YupX0EAfMN0wR1ToOpMDBN/wpimsVL/iavA+/GILIr4OIZNM7YsrLIYCIoumcozi6Kr0rP+8poOe4Az/919niYc22neRz8qNHoeAiUqdFbsRBFe9BvFfIKvyVXkiUmuf96dcK/N8owrW+tEttxSjN0eAeVjB7NB7rtIOrYezq5ol/ucTaHB1O+hK9ZQSLK1CHSTUv0fvJDsakkbcSrCViHXCVqkP/1Z8+KY8ZXBtpzdzGj754IlqsDKFujCYGlcWei26fqm+ZKyxXOKN3bZe7KgTOZDOYai5ZAMhe22TI/MEQ/PMp7STV75mTPI9ADlIqC/1sbfVccxaJawgzvMfEZV8R/SBEvMagqRXOV0JOfGBtSvJccIDYjmS8e0+Lmg/g9h19F2BronqIYf5hbxHYIyO1+SZDiXwZ/gBXn8aMe24j8gSblvBtsk5Mx3xejk0j0uGe+ABWbhWdB54uUc62XWXsZg13SBiM8hOdeUn4RjDgpZAsS0Rk12OIH5GrUxDYTzMpZteugihT0zES4EvK/N271tHzHDlwkdT4GD1mM1xroM22znN4zzf7Rd4sZ5DLpK0ErOd76w2q7oHvckzYSBeE+e6YTLchIhIl7svT1Y5CGQkzA7MB8wBwYFKw4DAhoEFBb3qY81ig89fj33bJ1fMbZ7bCXZBBTxELQIQzw2X2XApZIrBOECL9sH6wICB9A=";
+        private const string CertificatePassword = "awesome";
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -47,19 +51,37 @@ namespace SmtpServer.Tests
         }
 
         [Theory]
-        [InlineData("Assunto teste acento çãõáéíóú", "utf-8")]
-        [InlineData("שלום שלום שלום", "windows-1255")]
-        public void CanReceiveUnicodeMimeMessage(string text, string charset)
+        [InlineData("Assunto teste acento çãõáéíóú", "utf-8", true)]
+        [InlineData("שלום שלום שלום", "windows-1255", false)]
+        // Adjusted this test because "windows-1255" ending is not supported by .NET Core
+        public void CanReceiveUnicodeMimeMessage(string text, string charset, bool shouldPass)
         {
             using (CreateServer())
             {
-                // act
-                MailClient.Send(MailClient.Message(subject: text, text: text, charset: charset));
+                Exception exceptionCaught = null;
+                try
+                {
+                    // act
+                    MailClient.Send(MailClient.Message(subject: text, text: text, charset: charset));
+                }
+                catch (Exception ex)
+                {
+                    exceptionCaught = ex;
+                }
 
-                // assert
-                Assert.Single(MessageStore.Messages);
-                Assert.Equal(text, MessageStore.Messages[0].MimeMessage.Subject);
-                Assert.Equal(text, MessageStore.Messages[0].Text(charset));
+                if (shouldPass)
+                {
+                    // assert
+                    Assert.Null(exceptionCaught);
+                    Assert.Single(MessageStore.Messages);
+                    Assert.Equal(text, MessageStore.Messages[0].MimeMessage.Subject);
+                    Assert.Equal(text, MessageStore.Messages[0].Text(charset));
+                }
+                else
+                {
+                    //check if some exception was thrown
+                    Assert.NotNull(exceptionCaught);
+                }
             }
         }
 
@@ -86,6 +108,70 @@ namespace SmtpServer.Tests
                 Assert.Single(MessageStore.Messages);
                 Assert.Equal("user", user);
                 Assert.Equal("password", password);
+            }
+        }
+
+        [Fact]
+        public void ServerCanValidateIncomingClientCertificate()
+        {
+            // arrange
+            var wasConnectedEventRaised = false;
+
+            var clientCertificateValidator = new DelegatingClientCertificateValidator( (sender, certificate, chain, sslPolicyErrors) => true);
+            var mockCertificateChain = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(Base64Certificate), CertificatePassword));
+
+            var smtpClient = MailClient.Client();
+
+            smtpClient.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            smtpClient.ClientCertificates = mockCertificateChain;
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication().Certificate(new X509Certificate2(Convert.FromBase64String(Base64Certificate), CertificatePassword)), services => services.Add(clientCertificateValidator)))
+            {
+                // act
+                 smtpClient.Connect(onConnected: (s, e) => wasConnectedEventRaised = true, options: SecureSocketOptions.StartTls);
+
+                // assert
+                Assert.True(wasConnectedEventRaised);
+            }
+        }
+
+        [Fact]
+        public void ServerRefusesIncorrectIncomingClientCertificate()
+        {
+            // arrange
+            var wasConnectedEventRaised = false;
+
+            var clientCertificateValidator = new DelegatingClientCertificateValidator((sender, certificate, chain, sslPolicyErrors) => !string.IsNullOrWhiteSpace(certificate.Subject));
+            var mockCertificateChain = new X509Certificate2Collection(new X509Certificate2(new X509Certificate2()));
+
+            var smtpClient = MailClient.Client();
+            smtpClient.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            smtpClient.ClientCertificates = mockCertificateChain;
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication().Certificate(new X509Certificate2(Convert.FromBase64String(Base64Certificate), CertificatePassword)), services => services.Add(clientCertificateValidator)))
+            {
+                // act & assert
+                Assert.Throws<IOException>(() => smtpClient.Connect(onConnected: (s, e) => wasConnectedEventRaised = true, options: SecureSocketOptions.StartTls));
+                Assert.False(wasConnectedEventRaised);
+            }
+        }
+
+        [Fact]
+        public void ServerRefusesMissingIncomingClientCertificate()
+        {
+            // arrange
+            var wasConnectedEventRaised = false;
+
+            var clientCertificateValidator = new DelegatingClientCertificateValidator((sender, certificate, chain, sslPolicyErrors) => chain is not null || certificate is not null);
+
+            var smtpClient = MailClient.Client();
+            smtpClient.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication().Certificate(new X509Certificate2(Convert.FromBase64String(Base64Certificate), CertificatePassword)), services => services.Add(clientCertificateValidator)))
+            {
+                // act & assert
+                Assert.Throws<IOException>(() => smtpClient.Connect(onConnected: (s, e) => wasConnectedEventRaised = true, options: SecureSocketOptions.StartTls));
+                Assert.False(wasConnectedEventRaised);
             }
         }
 
@@ -141,7 +227,7 @@ namespace SmtpServer.Tests
         {
             using (CreateServer(c => c.CommandWaitTimeout(TimeSpan.FromSeconds(1))))
             {
-                var client = MailClient.Client();
+                var client = MailClient.Client().Connect();
                 client.NoOp();
 
                 for (var i = 0; i < 5; i++)
@@ -171,7 +257,7 @@ namespace SmtpServer.Tests
 
             using (CreateServer(services => services.Add(mailboxFilter)))
             {
-                using var client = MailClient.Client();
+                using var client = MailClient.Client().Connect();
 
                 Assert.Throws<ServiceNotAuthenticatedException>(() => client.Send(MailClient.Message()));
 
@@ -187,7 +273,7 @@ namespace SmtpServer.Tests
 
             using (CreateServer(services => services.Add(mailboxFilter)))
             {
-                using var client = MailClient.Client();
+                using var client = MailClient.Client().Connect();
 
                 Assert.Throws<ServiceNotAuthenticatedException>(() => client.Send(MailClient.Message()));
 
@@ -260,11 +346,11 @@ namespace SmtpServer.Tests
                     });
 
                 disposable.Server.SessionCreated += sessionCreatedHandler;
-                
+
                 MailClient.Send();
 
                 disposable.Server.SessionCreated -= sessionCreatedHandler;
-                
+
                 Assert.True(isSecure);
             }
 
@@ -289,11 +375,11 @@ namespace SmtpServer.Tests
                     });
 
                 disposable.Server.SessionCreated += sessionCreatedHandler;
-                
+
                 MailClient.NoOp(MailKit.Security.SecureSocketOptions.SslOnConnect);
 
                 disposable.Server.SessionCreated -= sessionCreatedHandler;
-                
+
                 Assert.True(isSecure);
             }
 
@@ -363,10 +449,12 @@ namespace SmtpServer.Tests
 
         public static X509Certificate2 CreateCertificate()
         {
-            var certificate = File.ReadAllBytes(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
-            var password = File.ReadAllText(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
+            // I decided to replace hardcoded path to certificate with Base64String test certificate :)
+            // Let me know if you disagree with this change :)
+            // var certificate = File.ReadAllBytes(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
+            // var password = File.ReadAllText(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
 
-            return new X509Certificate2(certificate, password);
+            return new X509Certificate2(Convert.FromBase64String(Base64Certificate), CertificatePassword);
         }
 
         /// <summary>

--- a/Src/SmtpServer/Authentication/ClientCertificateValidator.cs
+++ b/Src/SmtpServer/Authentication/ClientCertificateValidator.cs
@@ -3,8 +3,11 @@
 namespace SmtpServer.Authentication
 {
     /// <summary>
-    /// Represents a client certificate validator for validating client certificates.
+    /// Represents an abstract class for validating client certificates.
     /// </summary>
+    /// <remarks>
+    /// The validation of the client certificate will only take place if the client initiates the "STARTTLS" command.
+    /// </remarks>
     public abstract class ClientCertificateValidator : IClientCertificateValidator
     {
         /// <summary>
@@ -12,15 +15,15 @@ namespace SmtpServer.Authentication
         /// </summary>
         public static readonly IClientCertificateValidator Default = new DefaultClientCertificateValidator();
 
-        /// <inheritroc />
-        public abstract RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+        /// <inheritdoc />
+        public abstract RemoteCertificateValidationCallback RemoteClientCertificateValidationCallback { get; set; }
 
         /// <summary>
         /// Default implementation of a client certificate validator.
         /// </summary>
         sealed class DefaultClientCertificateValidator : ClientCertificateValidator
         {
-            public override RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = null;
+            public override RemoteCertificateValidationCallback RemoteClientCertificateValidationCallback { get; set; } = null;
         }
     }
 }

--- a/Src/SmtpServer/Authentication/ClientCertificateValidator.cs
+++ b/Src/SmtpServer/Authentication/ClientCertificateValidator.cs
@@ -1,0 +1,26 @@
+﻿using System.Net.Security;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Represents a client certificate validator for validating client certificates.
+    /// </summary>
+    public abstract class ClientCertificateValidator : IClientCertificateValidator
+    {
+        /// <summary>
+        /// The default client certificate validator used by the application.
+        /// </summary>
+        public static readonly IClientCertificateValidator Default = new DefaultClientCertificateValidator();
+
+        /// <inheritroc />
+        public abstract RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+
+        /// <summary>
+        /// Default implementation of a client certificate validator.
+        /// </summary>
+        sealed class DefaultClientCertificateValidator : ClientCertificateValidator
+        {
+            public override RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; } = null;
+        }
+    }
+}

--- a/Src/SmtpServer/Authentication/DelegatingClientCertificateValidator.cs
+++ b/Src/SmtpServer/Authentication/DelegatingClientCertificateValidator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace SmtpServer.Authentication
+{
+    public sealed class DelegatingClientCertificateValidator : ClientCertificateValidator
+    {
+        private readonly Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> _delegate;
+
+        /// <summary>
+        /// Represents a client certificate validator that delegates the certificate validation
+        /// logic to a specified function.
+        /// </summary>
+        public DelegatingClientCertificateValidator(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> @delegate)
+        {
+            _delegate = @delegate;
+        }
+
+        /// <summary>
+        /// Gets or sets the client certificate validation callback used for remote certificate validation.
+        /// </summary>
+        /// <value>
+        /// The certificate validation callback.
+        /// </value>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to set this property.</exception>
+        public override RemoteCertificateValidationCallback RemoteClientCertificateValidationCallback
+        {
+            get => (a,b,c,d) => _delegate(a,b,c,d);
+            set => throw new InvalidOperationException("Cannot set this property");
+        }
+    }
+}

--- a/Src/SmtpServer/Authentication/DelegatingClientCertificateValidatorFactory.cs
+++ b/Src/SmtpServer/Authentication/DelegatingClientCertificateValidatorFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SmtpServer.Authentication
+{
+    public class DelegatingClientCertificateValidatorFactory : IClientCertificateValidatorFactory
+    {
+        readonly Func<ISessionContext, IClientCertificateValidator> _delegate;
+
+        public DelegatingClientCertificateValidatorFactory(Func<ISessionContext, IClientCertificateValidator> @delegate)
+        {
+            _delegate = @delegate;
+        }
+
+        /// <summary>
+        /// Creates an instance of the service for the given session context.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <returns>The service instance for the session context.</returns>
+        public IClientCertificateValidator CreateInstance(ISessionContext context)
+        {
+            return _delegate(context);
+        }
+    }
+}

--- a/Src/SmtpServer/Authentication/IClientCertificateValidator.cs
+++ b/Src/SmtpServer/Authentication/IClientCertificateValidator.cs
@@ -1,0 +1,15 @@
+﻿using System.Net.Security;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Provides an interface for validating client certificates.
+    /// </summary>
+    public interface IClientCertificateValidator
+    {
+        /// <summary>
+        /// Gets or sets the callback method used to validate the client certificate provided by the remote party in a secure connection.
+        /// </summary>
+        RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+    }
+}

--- a/Src/SmtpServer/Authentication/IClientCertificateValidator.cs
+++ b/Src/SmtpServer/Authentication/IClientCertificateValidator.cs
@@ -10,6 +10,6 @@ namespace SmtpServer.Authentication
         /// <summary>
         /// Gets or sets the callback method used to validate the client certificate provided by the remote party in a secure connection.
         /// </summary>
-        RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+        RemoteCertificateValidationCallback RemoteClientCertificateValidationCallback { get; set; }
     }
 }

--- a/Src/SmtpServer/Authentication/IClientCertificateValidatorFactory.cs
+++ b/Src/SmtpServer/Authentication/IClientCertificateValidatorFactory.cs
@@ -1,0 +1,9 @@
+﻿using SmtpServer.ComponentModel;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Represents a factory for creating instances of <see cref="IClientCertificateValidator"/>.
+    /// </summary>
+    public interface IClientCertificateValidatorFactory : ISessionContextInstanceFactory<IClientCertificateValidator> { }
+}

--- a/Src/SmtpServer/ComponentModel/ServiceProvider.cs
+++ b/Src/SmtpServer/ComponentModel/ServiceProvider.cs
@@ -15,12 +15,14 @@ namespace SmtpServer.ComponentModel
         ISmtpCommandFactory _smtpCommandFactory;
         IMailboxFilterFactory _mailboxFilterFactory;
         IMessageStoreFactory _messageStoreFactory;
-        
+        IClientCertificateValidatorFactory _clientCertificateValidatorFactory;
+
         public ServiceProvider()
         {
             Add(UserAuthenticator.Default);
             Add(MailboxFilter.Default);
             Add(MessageStore.Default);
+            Add(ClientCertificateValidator.Default);
         }
 
         /// <summary>
@@ -96,6 +98,24 @@ namespace SmtpServer.ComponentModel
         }
 
         /// <summary>
+        /// Adds a client certificate validator factory to the application.
+        /// </summary>
+        /// <param name="clientCertificateValidatorFactory">The client certificate validator factory to add.</param>
+        public void Add(IClientCertificateValidatorFactory clientCertificateValidatorFactory)
+        {
+            _clientCertificateValidatorFactory = clientCertificateValidatorFactory;
+        }
+
+        /// <summary>
+        /// Adds a client certificate validator to the service.
+        /// </summary>
+        /// <param name="clientCertificateValidator">The client certificate validator to add.</param>
+        public void Add(IClientCertificateValidator clientCertificateValidator)
+        {
+            _clientCertificateValidatorFactory = new DelegatingClientCertificateValidatorFactory(context => clientCertificateValidator);
+        }
+
+        /// <summary>
         /// Gets the service object of the specified type.
         /// </summary>
         /// <param name="serviceType">An object that specifies the type of service object to get.</param>
@@ -125,6 +145,11 @@ namespace SmtpServer.ComponentModel
             if (serviceType == typeof(IMessageStoreFactory))
             {
                 return _messageStoreFactory;
+            }
+
+            if (serviceType == typeof(IClientCertificateValidatorFactory))
+            {
+                return _clientCertificateValidatorFactory;
             }
 
             throw new NotSupportedException(serviceType.ToString());

--- a/Src/SmtpServer/IO/ISecurableDuplexPipe.cs
+++ b/Src/SmtpServer/IO/ISecurableDuplexPipe.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO.Pipelines;
+using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -15,8 +16,9 @@ namespace SmtpServer.IO
         /// <param name="certificate">The X509Certificate used to authenticate the server.</param>
         /// <param name="protocols">The value that represents the protocol used for authentication.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="remoteCertificateValidationCallback">A user-provided callback method to validate the client certificate. If is null, no validation procedure will be performed</param>
         /// <returns>A task that asynchronously performs the operation.</returns>
-        Task UpgradeAsync(X509Certificate certificate, SslProtocols protocols, CancellationToken cancellationToken = default);
+        Task UpgradeAsync(X509Certificate certificate, SslProtocols protocols, CancellationToken cancellationToken = default, RemoteCertificateValidationCallback remoteCertificateValidationCallback = null);
 
         /// <summary>
         /// Returns a value indicating whether or not the current pipeline is secure.

--- a/Src/SmtpServer/Protocol/StartTlsCommand.cs
+++ b/Src/SmtpServer/Protocol/StartTlsCommand.cs
@@ -31,7 +31,7 @@ namespace SmtpServer.Protocol
 
             var clientCertificateValidator = context.ServiceProvider.GetService<IClientCertificateValidatorFactory, IClientCertificateValidator>(context, ClientCertificateValidator.Default);
 
-            await context.Pipe.UpgradeAsync(certificate, protocols, cancellationToken, clientCertificateValidator.RemoteCertificateValidationCallback).ConfigureAwait(false);
+            await context.Pipe.UpgradeAsync(certificate, protocols, cancellationToken, clientCertificateValidator.RemoteClientCertificateValidationCallback).ConfigureAwait(false);
 
             return true;
         }

--- a/Src/SmtpServer/Protocol/StartTlsCommand.cs
+++ b/Src/SmtpServer/Protocol/StartTlsCommand.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using SmtpServer.Authentication;
+using SmtpServer.ComponentModel;
 using SmtpServer.IO;
 
 namespace SmtpServer.Protocol
@@ -18,17 +20,18 @@ namespace SmtpServer.Protocol
         /// </summary>
         /// <param name="context">The execution context to operate on.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>Returns true if the command executed successfully such that the transition to the next state should occurr, false 
+        /// <returns>Returns true if the command executed successfully such that the transition to the next state should occur, false
         /// if the current state is to be maintained.</returns>
         internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
         {
             await context.Pipe.Output.WriteReplyAsync(SmtpResponse.ServiceReady, cancellationToken).ConfigureAwait(false);
 
             var certificate = context.EndpointDefinition.CertificateFactory.GetServerCertificate(context);
-
             var protocols = context.EndpointDefinition.SupportedSslProtocols;
 
-            await context.Pipe.UpgradeAsync(certificate, protocols, cancellationToken).ConfigureAwait(false);
+            var clientCertificateValidator = context.ServiceProvider.GetService<IClientCertificateValidatorFactory, IClientCertificateValidator>(context, ClientCertificateValidator.Default);
+
+            await context.Pipe.UpgradeAsync(certificate, protocols, cancellationToken, clientCertificateValidator.RemoteCertificateValidationCallback).ConfigureAwait(false);
 
             return true;
         }


### PR DESCRIPTION
Introduced a new interface that exposes `RemoteCertificateValidationCallback` for consumers to implement if needed. Unit tests are missing at the momet.